### PR TITLE
FEAT: Query DSL을 통한 검색 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ repositories {
     mavenCentral()
 }
 
+// QueryDSL 버전 설정
+ext {
+    queryDslVersion = "5.0.0"
+}
+
 dependencies {
     // gemini
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -48,6 +53,20 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2'
 
+    // QueryDSL 관련 의존성 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+        }
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spring/delivery/domain/controller/StoreController.java
+++ b/src/main/java/com/spring/delivery/domain/controller/StoreController.java
@@ -65,12 +65,14 @@ public class StoreController {
 
     @GetMapping("/search")
     public ResponseEntity<ApiResponseDto<Page<StoreListResponseDto>>> searchStores(
-            @RequestParam String query,
+            @RequestParam(required = false) String storeName,    // 지점 이름 (선택적)
+            @RequestParam(required = false) String categoryName, // 카테고리 (선택적)
             @RequestParam(value = "page") int page,
             @RequestParam(value = "size") int size,
             @RequestParam(value = "sortBy") String sortBy,
             @RequestParam(value = "isAsc") boolean isAsc) {
-        ApiResponseDto<Page<StoreListResponseDto>> responseDto = storeService.searchStores(query, page, size, sortBy, isAsc);
+
+        ApiResponseDto<Page<StoreListResponseDto>> responseDto = storeService.searchStores(storeName, categoryName, page, size, sortBy, isAsc);
 
         return ResponseEntity.status(responseDto.getStatus()).body(responseDto);
     }

--- a/src/main/java/com/spring/delivery/domain/domain/repository/StoreRepository.java
+++ b/src/main/java/com/spring/delivery/domain/domain/repository/StoreRepository.java
@@ -1,6 +1,7 @@
 package com.spring.delivery.domain.domain.repository;
 
 import com.spring.delivery.domain.domain.entity.Store;
+import com.spring.delivery.domain.domain.repository.search.StoreSearch;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,13 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface StoreRepository extends JpaRepository<Store, UUID> {
+public interface StoreRepository extends JpaRepository<Store, UUID>, StoreSearch {
     Page<Store> findByDeletedAtIsNull(Pageable pageable); // pageable을 인자로 받는 메서드 추가
-
-    @Query("SELECT s FROM Store s WHERE s.deletedAt IS NULL AND " +
-            "(LOWER(s.name) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-            " LOWER(s.address) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
-            " LOWER(s.tel) LIKE LOWER(CONCAT('%', :query, '%')))")
-    Page<Store> searchStores(String query, Pageable pageable);
 }
 

--- a/src/main/java/com/spring/delivery/domain/domain/repository/search/StoreSearch.java
+++ b/src/main/java/com/spring/delivery/domain/domain/repository/search/StoreSearch.java
@@ -1,0 +1,9 @@
+package com.spring.delivery.domain.domain.repository.search;
+
+import com.spring.delivery.domain.domain.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface StoreSearch {
+    Page<Store> searchStores(String category, String storeName, Pageable pageable);
+}

--- a/src/main/java/com/spring/delivery/domain/domain/repository/search/StoreSearchImpl.java
+++ b/src/main/java/com/spring/delivery/domain/domain/repository/search/StoreSearchImpl.java
@@ -1,0 +1,53 @@
+package com.spring.delivery.domain.domain.repository.search;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import com.spring.delivery.domain.domain.entity.QStore;
+import com.spring.delivery.domain.domain.entity.QStoreCategory;
+import com.spring.delivery.domain.domain.entity.Store;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StoreSearchImpl implements StoreSearch {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Store> searchStores(String categoryName, String storeName, Pageable pageable) {
+        QStore store = QStore.store;
+        QStoreCategory storeCategory = QStoreCategory.storeCategory; // 중간 테이블 Q타입 추가
+
+        // 기본 쿼리
+        JPAQuery<Store> query = queryFactory.selectFrom(store)
+                .join(store.storeCategories, storeCategory)
+                .where(store.deletedAt.isNull()); // 중간 테이블을 통한 조인
+
+        // 카테고리 필터링
+        if (categoryName != null && !categoryName.isEmpty()) {
+            query.where(storeCategory.category.name.eq(categoryName)); // StoreCategory의 Category를 조인
+        }
+
+        // 지점 이름 필터링
+        if (storeName != null && !storeName.isEmpty()) {
+            query.where(store.name.contains(storeName));
+        }
+
+        // 페이징 처리
+        List<Store> stores = query.offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = query.fetchCount();
+
+        return new PageImpl<>(stores, pageable, total);
+    }
+}
+

--- a/src/main/java/com/spring/delivery/domain/service/StoreService.java
+++ b/src/main/java/com/spring/delivery/domain/service/StoreService.java
@@ -234,7 +234,7 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public ApiResponseDto<Page<StoreListResponseDto>> searchStores(String query, int page, int size, String sortBy, boolean isAsc) {
+    public ApiResponseDto<Page<StoreListResponseDto>> searchStores(String storeName, String categoryName, int page, int size, String sortBy, boolean isAsc) {
         // 페이지당 노출 건수 제한
         if (size != 10 && size != 30 && size != 50) {
             size = 10; // 기본값으로 10으로 설정
@@ -251,29 +251,31 @@ public class StoreService {
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
 
         // 검색 수행
-        Page<Store> storePage = storeRepository.searchStores(query, pageable);
+        Page<Store> storePage = storeRepository.searchStores(categoryName, storeName, pageable);
 
         // Store 객체를 StoreListResponseDto로 변환
-        Page<StoreListResponseDto> responseDtoPage = storePage.map(store -> {
+        Page<StoreListResponseDto> responseDtoPage = storePage.map(storeEntity -> {
             // 카테고리 처리
-            List<String> categories = store.getStoreCategories().stream()
+            List<String> categories = storeEntity.getStoreCategories().stream()
                     .map(storeCategory -> storeCategory.getCategory().getName())
                     .collect(Collectors.toList());
 
             return new StoreListResponseDto(
-                    store.getId(),
-                    store.getName(),
-                    store.getAddress(),
-                    store.getTel(),
-                    store.isOpenStatus(),
+                    storeEntity.getId(),
+                    storeEntity.getName(),
+                    storeEntity.getAddress(),
+                    storeEntity.getTel(),
+                    storeEntity.isOpenStatus(),
                     categories,
-                    store.getStartTime(),
-                    store.getEndTime()
+                    storeEntity.getStartTime(),
+                    storeEntity.getEndTime()
             );
         });
 
         // ApiResponseDto로 응답 반환
         return ApiResponseDto.success(responseDtoPage);
     }
+
+
 
 }

--- a/src/main/java/com/spring/delivery/global/config/QueryDslConfig.java
+++ b/src/main/java/com/spring/delivery/global/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package com.spring.delivery.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
🚅 PR 한 줄 요약
Query DSL을 통한 가게 검색 구현

🧑‍💻 PR 세부 내용
- 쿼리 파라미터로 카테고리만 입력되면 해당 카테고리의 모든 지점이 노출
- 카테고리와 지점 이름이 입력되면 해당 카테고리에 포함되어있으며, 검색한 지점 이름을 포함하는 지점들이 노출

📸 스크린샷
- 카테고리만 검색
![카테고리만 검색](https://github.com/user-attachments/assets/8471c6cc-c55c-441b-a733-95640250177a)
- 카테고리와 가게 이름을 함께 검색
![카테고리 가게 같이 검색](https://github.com/user-attachments/assets/b3f0b76c-efb7-4aa7-8098-a0841992330f)
