### PR TITLE
Feature/79 menu gemini testcode

### DIFF
--- a/src/main/java/com/spring/delivery/domain/controller/MenuController.java
+++ b/src/main/java/com/spring/delivery/domain/controller/MenuController.java
@@ -2,8 +2,8 @@ package com.spring.delivery.domain.controller;
 
 
 import com.spring.delivery.domain.controller.dto.ApiResponseDto;
-import com.spring.delivery.domain.controller.dto.order.MenuRequestDto;
-import com.spring.delivery.domain.controller.dto.order.MenuResponseDto;
+import com.spring.delivery.domain.controller.dto.menu.MenuRequestDto;
+import com.spring.delivery.domain.controller.dto.menu.MenuResponseDto;
 import com.spring.delivery.domain.service.MenuService;
 import com.spring.delivery.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -24,13 +24,6 @@ import java.util.UUID;
 public class MenuController {
 
     private final MenuService menuService;
-
-    @GetMapping("test1")
-    public ResponseEntity<String> checkApi(Authentication authentication) {
-        System.out.println("메뉴 API 테스트 엔드포인트 실행됨!");
-        System.out.println("현재 사용자 권한: " + authentication.getAuthorities());
-        return ResponseEntity.ok("메뉴 API가 정상 작동 중입니다.");
-    }
 
     @PostMapping
     public ResponseEntity<ApiResponseDto<MenuResponseDto>> createMenu(
@@ -70,10 +63,10 @@ public class MenuController {
     // 메뉴 단건(상세) 조회
     @GetMapping("/{menuId}")
     public ResponseEntity<ApiResponseDto<MenuResponseDto>> getMenuDetail(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable UUID menuId
     ) {
-
-        ApiResponseDto<MenuResponseDto> responseDto = menuService.getMenuDetail(menuId);
+        ApiResponseDto<MenuResponseDto> responseDto = menuService.getMenuDetail(userDetails, menuId);
 
         return ResponseEntity.status(responseDto.getStatus()).body(responseDto);
     }
@@ -81,14 +74,31 @@ public class MenuController {
     // 모든 메뉴 리스트
     @GetMapping
     public ResponseEntity<ApiResponseDto<Map<String, Object>>> getMenus(
-            @RequestParam UUID store_id,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) UUID store_id,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "30") int size,
             @RequestParam(defaultValue = "createdAt") String sort,
             @RequestParam(defaultValue = "desc") String order
     ) {
 
-        ApiResponseDto<Map<String, Object>> responseDto = menuService.getMenusByStore(store_id, page, size, sort, order);
+        ApiResponseDto<Map<String, Object>> responseDto = menuService.getMenusByStore(userDetails, store_id, page, size, sort, order);
+
+        return ResponseEntity.status(responseDto.getStatus()).body(responseDto);
+    }
+
+    /* 검색 */
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponseDto<Map<String, Object>>> searchMenus(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(required = false) UUID storeId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "30") int size,
+            @RequestParam(defaultValue = "createdAt") String sort,
+            @RequestParam(defaultValue = "desc") String order) {
+
+        ApiResponseDto<Map<String, Object>> responseDto = menuService.searchMenus(userDetails, storeId, keyword, page, size, sort, order);
 
         return ResponseEntity.status(responseDto.getStatus()).body(responseDto);
     }

--- a/src/main/java/com/spring/delivery/domain/controller/dto/menu/MenuRequestDto.java
+++ b/src/main/java/com/spring/delivery/domain/controller/dto/menu/MenuRequestDto.java
@@ -1,0 +1,45 @@
+package com.spring.delivery.domain.controller.dto.menu;
+
+
+import com.spring.delivery.domain.domain.entity.Menu;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class MenuRequestDto {
+
+    // 메뉴명
+    private String name;
+
+    // 메뉴 가격
+    private Long price;
+
+    // 메뉴 설명
+    private String description;
+
+    // 메뉴 이미지 url
+    private String menuImage;
+
+    // 메뉴 노출 상태
+    private Boolean publicStatus;
+
+    // 가게 ID
+    private UUID storeId;
+
+    public static MenuRequestDto of(String name, Long price, String description, String menuImage, Boolean publicStatus, UUID storeId) {
+        MenuRequestDto menuRequestDto = new MenuRequestDto();
+        menuRequestDto.name = name;
+        menuRequestDto.price = price;
+        menuRequestDto.description = description;
+        menuRequestDto.menuImage = menuImage;
+        menuRequestDto.publicStatus = publicStatus;
+        menuRequestDto.storeId = storeId;
+        return menuRequestDto;
+    }
+
+
+}

--- a/src/main/java/com/spring/delivery/domain/controller/dto/menu/MenuResponseDto.java
+++ b/src/main/java/com/spring/delivery/domain/controller/dto/menu/MenuResponseDto.java
@@ -1,0 +1,54 @@
+package com.spring.delivery.domain.controller.dto.menu;
+
+import com.spring.delivery.domain.domain.entity.Menu;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Getter
+@NoArgsConstructor
+public class MenuResponseDto {
+
+    private UUID id;
+    private String name;
+    private Long price;
+    private String description;
+    private Boolean publicStatus;
+    private String menuImage;
+    private UUID storeId;
+    private LocalDateTime createdAt;
+    private String createdBy;
+
+
+    @Builder
+    private MenuResponseDto(UUID id, String name, Long price, String description, Boolean publicStatus, String menuImage, UUID storeId, LocalDateTime createdAt, String createdBy) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.publicStatus = publicStatus;
+        this.menuImage = menuImage;
+        this.storeId = storeId;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+    }
+
+    public static MenuResponseDto from(Menu menu) {
+        return MenuResponseDto.builder()
+                .id(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .description(menu.getDescription())
+                .publicStatus(menu.isPublicStatus())
+                .menuImage(menu.getMenuImage())
+                .storeId(menu.getStore().getId())
+                .createdAt(menu.getCreatedAt())
+                .createdBy(menu.getCreatedBy())
+                .build();
+    }
+
+}

--- a/src/main/java/com/spring/delivery/domain/controller/dto/order/MenuResponseDto.java
+++ b/src/main/java/com/spring/delivery/domain/controller/dto/order/MenuResponseDto.java
@@ -28,8 +28,8 @@ public class MenuResponseDto {
         this.name = menu.getName();
         this.price = menu.getPrice();
         this.description = menu.getDescription();
-        this.publicStatus = menu.isPublic_status();
-        this.menuImage = menu.getMenu_image();
+        this.publicStatus = menu.isPublicStatus();
+        this.menuImage = menu.getMenuImage();
         this.storeId = menu.getStore().getId();
         this.createdAt = menu.getCreatedAt();
         this.createdBy = menu.getCreatedBy();

--- a/src/main/java/com/spring/delivery/domain/domain/entity/Menu.java
+++ b/src/main/java/com/spring/delivery/domain/domain/entity/Menu.java
@@ -1,6 +1,6 @@
 package com.spring.delivery.domain.domain.entity;
 
-import com.spring.delivery.domain.controller.dto.order.MenuRequestDto;
+import com.spring.delivery.domain.controller.dto.menu.MenuRequestDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -31,10 +31,10 @@ public class Menu extends BaseEntity {
     private String description;
 
     @Column(name = "public_status")
-    private boolean public_status;
+    private boolean publicStatus;
 
     @Column(name = "menu_image")
-    private String menu_image;
+    private String menuImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id", nullable = false)
@@ -44,12 +44,12 @@ public class Menu extends BaseEntity {
     private List<MenuOrder> menuOrderList = new ArrayList<>();
 
 
-    private Menu(String name, Long price, String description, boolean public_status, String menu_image, Store store) {
+    private Menu(String name, Long price, String description, boolean publicStatus, String menuImage, Store store) {
         this.name = name;
         this.price = price;
         this.description = description;
-        this.public_status = public_status;
-        this.menu_image = menu_image;
+        this.publicStatus = publicStatus;
+        this.menuImage = menuImage;
         this.store = store;
     }
 
@@ -68,13 +68,13 @@ public class Menu extends BaseEntity {
         if (requestDto.getName() != null) menu.name = requestDto.getName();
         if (requestDto.getPrice() != null) menu.price = requestDto.getPrice();
         if (requestDto.getDescription() != null) menu.description = requestDto.getDescription();
-        if (requestDto.getPublicStatus() != null) menu.public_status = requestDto.getPublicStatus();
-        if (requestDto.getMenuImage() != null) menu.menu_image = requestDto.getMenuImage();
+        if (requestDto.getPublicStatus() != null) menu.publicStatus = requestDto.getPublicStatus();
+        if (requestDto.getMenuImage() != null) menu.menuImage = requestDto.getMenuImage();
     }
 
     public void delete(String deletedBy) {
         super.delete(deletedBy);
-        this.public_status = false;
+        this.publicStatus = false;
     }
 
 

--- a/src/main/java/com/spring/delivery/domain/domain/repository/MenuRepository.java
+++ b/src/main/java/com/spring/delivery/domain/domain/repository/MenuRepository.java
@@ -1,6 +1,7 @@
 package com.spring.delivery.domain.domain.repository;
 
 import com.spring.delivery.domain.domain.entity.Menu;
+import com.spring.delivery.infra.gemini.Gemini;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,11 +15,25 @@ import java.util.UUID;
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
 
     // 단건 조회
-    @Query("SELECT m FROM Menu m WHERE m.id = :menuId AND m.public_status = true")
+    @Query("SELECT m FROM Menu m WHERE m.id = :menuId AND m.publicStatus = true")
     Optional<Menu> findActiveMenuById(@Param("menuId") UUID menuId);
 
-    // 메뉴 전체 리스트 조회
-    @Query("SELECT m FROM Menu m WHERE m.store.id = :storeId AND m.public_status = true")
+    // 메뉴 전체 리스트 조회 가게별
+    @Query("SELECT m FROM Menu m WHERE m.store.id = :storeId AND m.publicStatus = true")
     Page<Menu> findActiveMenusByStoreId(@Param("storeId") UUID storeId, Pageable pageable);
+
+    // 메뉴 전체 리스트 조회
+    @Query("SELECT m FROM Menu m WHERE m.publicStatus = true")
+    Page<Menu> findActiveMenus(Pageable pageable);
+
+    // 모든 메뉴 내역 중, 특정 키워드를 포함한 결과
+    Page<Menu> findByNameContaining(String keyword, Pageable pageable);
+
+    // 가게별 메뉴 내역 조회(전체)
+    Page<Menu> findByStoreId(UUID storeId, Pageable pageable);
+
+    // 가게별, 특정 키워드를 포함한 결과
+    Page<Menu> findByStoreIdAndNameContaining(UUID storeId, String keyword, Pageable pageable);
+
 
 }

--- a/src/main/java/com/spring/delivery/infra/exception/GeminiApiException.java
+++ b/src/main/java/com/spring/delivery/infra/exception/GeminiApiException.java
@@ -1,9 +1,0 @@
-package com.spring.delivery.infra.exception;
-
-public class GeminiApiException extends GeminiException {
-
-    // api 호출 실패, 500
-    public GeminiApiException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/spring/delivery/infra/exception/GeminiException.java
+++ b/src/main/java/com/spring/delivery/infra/exception/GeminiException.java
@@ -1,7 +1,12 @@
 package com.spring.delivery.infra.exception;
 
+import org.springframework.http.HttpStatus;
+
 public class GeminiException extends RuntimeException {
     public GeminiException(String message) {
         super(message);
     }
+
+
+
 }

--- a/src/main/java/com/spring/delivery/infra/exception/GeminiExceptionHandler.java
+++ b/src/main/java/com/spring/delivery/infra/exception/GeminiExceptionHandler.java
@@ -14,36 +14,32 @@ import java.util.concurrent.TimeoutException;
 @RestControllerAdvice(basePackages = "infra")
 public class GeminiExceptionHandler {
 
-    // 응답 시간 초과 (504)
-    @ExceptionHandler(GeminiTimeoutException.class)
-    public ResponseEntity<ApiResponseDto<String>> handleTimeoutException(GeminiTimeoutException e) {
-        log.warn("AI 추천 서비스 응답 시간 초과 - {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
-                .body(ApiResponseDto.fail(504, "AI 추천 서비스 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요."));
-    }
-
-    // Gemini API 서버 다운(503)
-    @ExceptionHandler(GeminiServiceUnavailableException.class)
-    public ResponseEntity<ApiResponseDto<String>> handleServiceUnavailable(GeminiServiceUnavailableException e) {
-        log.warn("AI 추천 서비스 다운 - {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
-                .body(ApiResponseDto.fail(503, "현재 AI 추천 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해 주세요."));
-    }
-
-    // Gemini API 호출 실패 (500)
-    @ExceptionHandler(GeminiApiException.class)
-    public ResponseEntity<ApiResponseDto<String>> handleApiException(GeminiApiException e) {
-        log.error("AI 추천 서비스 오류 - {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponseDto.fail(500, "AI 추천 서비스 요청 중 오류가 발생했습니다."));
-    }
-
     // 모든 Gemini 예외 처리 (500)
     @ExceptionHandler(GeminiException.class)
-    public ResponseEntity<ApiResponseDto<String>> handleGenericGeminiException(GeminiException e) {
-        log.error("Gemini API 예외 발생 - {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponseDto.fail(500, "Gemini 서비스에서 오류가 발생했습니다."));
+    public ResponseEntity<ApiResponseDto<String>> handleGeminiException(GeminiException e) {
+        HttpStatus status = getStatus(e);
+
+        if (status == HttpStatus.GATEWAY_TIMEOUT) {
+            log.warn("AI 추천 서비스 응답 시간 초과 - {}", e.getMessage());
+        } else if (status == HttpStatus.SERVICE_UNAVAILABLE) {
+            log.warn("AI 추천 서비스 다운 - {}", e.getMessage());
+        } else {
+            log.error("Gemini API 예외 발생 - {}", e.getMessage());
+        }
+
+        return ResponseEntity.status(status)
+                .body(ApiResponseDto.fail(status.value(), e.getMessage()));
+    }
+
+    private HttpStatus getStatus(GeminiException e) {
+        if (e instanceof GeminiTimeoutException) {
+            return HttpStatus.GATEWAY_TIMEOUT; // 504
+        } else if(e instanceof GeminiServiceUnavailableException) {
+            return HttpStatus.SERVICE_UNAVAILABLE; // 503
+        } else {
+            return HttpStatus.INTERNAL_SERVER_ERROR; // 500
+        }
+
     }
 
 }

--- a/src/test/java/com/spring/delivery/domain/service/GeminiServiceTest.java
+++ b/src/test/java/com/spring/delivery/domain/service/GeminiServiceTest.java
@@ -1,0 +1,198 @@
+package com.spring.delivery.domain.service;
+
+import com.spring.delivery.domain.controller.dto.ApiResponseDto;
+import com.spring.delivery.domain.domain.entity.Store;
+import com.spring.delivery.domain.domain.repository.StoreRepository;
+import com.spring.delivery.global.security.UserDetailsImpl;
+import com.spring.delivery.infra.exception.GeminiServiceUnavailableException;
+import com.spring.delivery.infra.exception.GeminiTimeoutException;
+import com.spring.delivery.infra.gemini.Gemini;
+import com.spring.delivery.infra.gemini.GeminiRepository;
+import com.spring.delivery.infra.gemini.GeminiResponseDto;
+import com.spring.delivery.infra.gemini.GeminiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD) // 각 테스트마다 새 인스턴스 생성
+@ExtendWith(MockitoExtension.class)
+class GeminiServiceTest {
+
+    private static final Logger log = LoggerFactory.getLogger(GeminiServiceTest.class);
+
+
+    @Mock
+    private WebClient webClient; // Gemini API 호출 Mocking
+
+    @Mock
+    private GeminiRepository geminiRepository; // DB 저장 Mocking
+
+    @Mock
+    private StoreRepository storeRepository; // Store 조회 Mocking
+
+    @Mock
+    private UserDetailsImpl userDetails; // 사용자 권한 Mocking
+
+    @Spy
+    @InjectMocks
+    private GeminiService geminiService;
+
+    @BeforeEach
+    protected void setUpCommon() {
+        // 모든 목 객체 초기화
+        //Mockito.reset(webClient, storeRepository, geminiRepository, userDetails);
+        Mockito.clearInvocations(webClient, storeRepository, geminiRepository, userDetails);
+        // WebClient 필드를 목 객체로 강제 주입
+        ReflectionTestUtils.setField(geminiService, "webClient", webClient);
+
+        ReflectionTestUtils.setField(geminiService, "geminiApiUrl", "https://dummyApi.com/");
+        ReflectionTestUtils.setField(geminiService, "geminiApiKey", "dummyKey");
+    }
+
+
+    @Test
+    @DisplayName("추천 응답 저장 성공")
+    void testSaveAiSuggestion_Success() {
+        // given
+        Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_MASTER"));
+        doReturn(authorities).when(userDetails).getAuthorities();
+
+        UUID storeId = UUID.randomUUID();
+        String requestText = "테스트";
+        String geminiResponse = "{ \"candidates\": [{ \"content\": { \"parts\": [{ \"text\": \"테스트\" }] } }] }";
+
+        Store mockStore = mock(Store.class);
+        when(mockStore.getId()).thenReturn(storeId);
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+
+        // 외부 api 호출
+        WebClient.RequestBodyUriSpec requestBodySpec = mock(WebClient.RequestBodyUriSpec.class);
+        WebClient.RequestHeadersSpec<?> requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+        // 메서드 호출을 가로채서 목 객체를 반환
+        // http post 요청 생성
+        when(webClient.post()).thenAnswer(invocation -> requestBodySpec);
+        // 요청할 url 지정
+        when(requestBodySpec.uri(anyString())).thenAnswer(invocation -> requestBodySpec);
+        // http 헤더 추가
+        when(requestBodySpec.header(anyString(), any())).thenAnswer(invocation -> requestBodySpec);
+        // 요청 본문 추가
+        when(requestBodySpec.bodyValue(any())).thenAnswer(invocation -> requestHeadersSpec);
+        // 요청을 보내고 응답 받음
+        when(requestHeadersSpec.retrieve()).thenAnswer(invocation -> responseSpec);
+        // 응답을 json 문자열로 반환
+        when(responseSpec.bodyToMono(String.class)).thenAnswer(invocation -> Mono.just(geminiResponse));
+
+        Gemini mockGemini = mock(Gemini.class);
+
+        when(geminiRepository.save(any(Gemini.class))).thenReturn(mockGemini);
+
+        // when
+        ApiResponseDto<GeminiResponseDto> response = geminiService.saveAiSuggestion(requestText, storeId, userDetails);
+
+        // then
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+        assertNotNull(response.getData().getResponseText());
+        assertFalse(response.getData().getResponseText().isEmpty());
+
+    }
+
+    @Test
+    @DisplayName("권한 부족 403")
+    void testSaveAiSuggestion_Forbidden() {
+        // given
+        // 기존 셋업에서 owner로 고정되어 있어 덮어쓰기가 필요
+        Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_CUSTOMER"));
+        doReturn(authorities).when(userDetails).getAuthorities();
+
+        // when
+        ApiResponseDto<GeminiResponseDto> response = geminiService.saveAiSuggestion("추천할 메뉴는?", UUID.randomUUID(), userDetails);
+
+        // then
+        assertEquals(HttpStatus.FORBIDDEN.value(), response.getStatus());
+        assertEquals("생성할 권한이 없습니다.", response.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("gemini api 응답 지연 - 504")
+    void testSaveAiSuggestion_GeminiTimeout() {
+        // given
+        // 기존 셋업에서 owner로 고정되어 있어 덮어쓰기가 필요
+        Set<GrantedAuthority> authorities = Set.of(new SimpleGrantedAuthority("ROLE_OWNER"));
+        doReturn(authorities).when(userDetails).getAuthorities();
+
+        UUID storeId = UUID.randomUUID();
+        Store mockStore = mock(Store.class);
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(mockStore));
+
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+        WebClient.RequestHeadersSpec<?> requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.post()).thenAnswer(invocation -> requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenAnswer(invocation -> requestBodyUriSpec);
+        when(requestBodyUriSpec.header(anyString(), any())).thenAnswer(invocation -> requestBodyUriSpec);
+        when(requestBodyUriSpec.bodyValue(any())).thenAnswer(invocation -> requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenAnswer(invocation -> responseSpec);
+
+
+        WebClientRequestException timeoutException = new WebClientRequestException(
+                new IOException("Timeout Exception"),
+                HttpMethod.POST,
+                URI.create("https://dummy.com"),
+                HttpHeaders.EMPTY
+        );
+        doThrow(timeoutException).when(responseSpec).bodyToMono(String.class);
+
+        // when & then
+        Exception thrown = assertThrows(Exception.class, () -> {
+            geminiService.saveAiSuggestion("테스트", storeId, userDetails);
+        });
+
+        Throwable unwrapped = reactor.core.Exceptions.unwrap(thrown);
+        unwrapped = reactor.core.Exceptions.unwrap(unwrapped); // 두 번 언랩!
+
+        assertTrue(unwrapped instanceof GeminiTimeoutException);
+        assertTrue(unwrapped.getMessage().contains("Gemini API 추천 서비스 응답 시간이 초과되었습니다."));
+        assertTrue(unwrapped.getMessage().contains("Timeout Exception"));
+    }
+
+}
+
+

--- a/src/test/java/com/spring/delivery/domain/service/MenuServiceTest.java
+++ b/src/test/java/com/spring/delivery/domain/service/MenuServiceTest.java
@@ -1,0 +1,209 @@
+package com.spring.delivery.domain.service;
+
+import com.spring.delivery.domain.controller.dto.ApiResponseDto;
+import com.spring.delivery.domain.controller.dto.menu.MenuRequestDto;
+import com.spring.delivery.domain.controller.dto.menu.MenuResponseDto;
+import com.spring.delivery.domain.domain.entity.Menu;
+import com.spring.delivery.domain.domain.entity.Store;
+import com.spring.delivery.domain.domain.entity.User;
+import com.spring.delivery.domain.domain.entity.enumtype.Role;
+import com.spring.delivery.domain.domain.repository.MenuRepository;
+import com.spring.delivery.domain.domain.repository.StoreRepository;
+import com.spring.delivery.domain.domain.repository.UserRepository;
+import com.spring.delivery.global.security.UserDetailsImpl;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static com.spring.delivery.domain.domain.entity.User.createUser;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class MenuServiceTest {
+
+    @Autowired
+    MenuService menuService;
+
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    User ownerUser;
+    User customerUser;
+    UserDetailsImpl ownerUserDetails;
+    UserDetailsImpl customerUserDetails;
+
+    Store store;
+    MenuResponseDto createdMenu = null;
+    Menu testMenu;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 유저 생성
+        ownerUser = userRepository.findByEmail("owner2@email.com")
+                .orElseGet(() -> {
+                    User ownerUser2 = createUser("owner2","owner2@eamil.com","1234", Role.OWNER);
+                    return userRepository.save(ownerUser2);
+                });
+
+        customerUser = userRepository.findByEmail("customer2@email.com")
+                .orElseGet(() -> {
+                    User customerUser2 = createUser("customer2","customer2@eamil.com","1234", Role.CUSTOMER);
+                    return userRepository.save(customerUser2);
+                });
+
+        ownerUserDetails = new UserDetailsImpl(ownerUser);
+        customerUserDetails = new UserDetailsImpl(customerUser);
+
+        // 테스트를 위한 스토어 생성
+        store = Store.of(
+                "테스트 가게",
+                "테스트 주소",
+                "010-1234-5678",
+                true,
+                LocalTime.now(),
+                LocalTime.now(),
+                ownerUser
+                );
+        storeRepository.save(store);
+
+
+        testMenu = menuRepository.save(Menu.of(
+                MenuRequestDto.of(
+                        "테스트메뉴",
+                        10000L,
+                        "테스트메뉴입니다.",
+                        "image.jpg",
+                        true,
+                        store.getId()),
+                store
+        ));
+    }
+
+    @Test
+    @Order(1)
+    @Transactional
+    @DisplayName("신규 메뉴 등록")
+    void testSuccessCreateMenu() {
+        // given
+        String name = "테스트 메뉴";
+        Long price = 15000L;
+        String description = "이것은 테스트 메뉴입니다.";
+        String menuImage = "http://images.com/menu.jpg";
+        Boolean publicStatus = true;
+
+        MenuRequestDto requestDto = MenuRequestDto.of(
+                name,
+                price,
+                description,
+                menuImage,
+                publicStatus,
+                store.getId()
+        );
+
+        // when
+        MenuResponseDto menu = menuService.createMenu(requestDto, ownerUserDetails).getData();
+
+        // then
+        assertNotNull(menu.getId());
+        assertEquals(name, menu.getName());
+        assertEquals(price, menu.getPrice());
+        assertEquals(description, menu.getDescription());
+        assertEquals(menuImage, menu.getMenuImage());
+        assertEquals(publicStatus, menu.getPublicStatus());
+        assertEquals(store.getId(), menu.getStoreId());
+
+        createdMenu = menu;
+    }
+
+    @Test
+    @Order(2)
+    @Transactional
+    @DisplayName("신규 메뉴 등록 실패-권한없음")
+    void testFailCreateMenu() {
+        // given
+        MenuRequestDto requestDto = MenuRequestDto.of(
+                "테스트 메뉴",
+                15000L,
+                "이것은 테스트 메뉴입니다.",
+                "http://images.com/menu.jpg",
+                true,
+                store.getId()
+        );
+
+        // when
+        ApiResponseDto<MenuResponseDto> response = menuService.createMenu(requestDto, customerUserDetails);
+
+        // then
+        assertEquals(403, response.getStatus());
+        assertEquals("메뉴를 생성할 권한이 없습니다.", response.getMessage());
+        assertNull(response.getData());
+    }
+
+    @Test
+    @Order(3)
+    @Transactional
+    @DisplayName("메뉴 수정 성공")
+    void testSuccessUpdateMenu() {
+        // given
+        UUID menuId = testMenu.getId();
+        String updatedName = "수정된 메뉴";
+        Long updatedPrice = 20000L;
+        String updatedDescription = "이것은 수정된 메뉴입니다.";
+        String updatedMenuImage = "http://images.com/updated-menu.jpg";
+        Boolean updatedPublicStatus = false;
+
+        MenuRequestDto requestDto = MenuRequestDto.of(
+                updatedName,
+                updatedPrice,
+                updatedDescription,
+                updatedMenuImage,
+                updatedPublicStatus,
+                store.getId()
+        );
+
+        // when
+        menuService.updateMenu(menuId, requestDto, ownerUserDetails);
+
+        // then
+        Menu updatedMenu = menuRepository.findById(menuId)
+                        .orElseThrow(() -> new IllegalStateException("수정된 메뉴를 찾을 수 없습니다."));
+
+        assertEquals(updatedName, updatedMenu.getName());
+        assertEquals(updatedPrice, updatedMenu.getPrice());
+        assertEquals(updatedDescription, updatedMenu.getDescription());
+        assertEquals(updatedMenuImage, updatedMenu.getMenuImage());
+        assertEquals(updatedPublicStatus, updatedMenu.isPublicStatus());
+    }
+
+
+    @Test
+    @Order(4)
+    @DisplayName("메뉴 상세 조회 성공")
+    void testGetMenuDetail() {
+        // given
+        UUID id = testMenu.getId();
+
+        // when
+        ApiResponseDto<MenuResponseDto> response = menuService.getMenuDetail(ownerUserDetails, id);
+
+        // then
+        assertEquals(200, response.getStatus());
+    }
+
+
+
+}
+


### PR DESCRIPTION
🚅 PR 한 줄 요약  
메뉴 검색 기능 추가하였고, 메뉴에 권한 확인이 빠져있어 추가하였고, 메뉴 응답&요청 DTO파일 위치를 패키지컨벤션에 맞추어 변경하였습니다.
제미나이 응답 호출 실패시 재시도하는 로직을 추가하였습니다.(코드 한줄 추가됨)
메뉴와 제미나이의 서비스 테스트 코드를 추가하였습니다.

+ 대중님, '메뉴'의 컨트롤러, 엔티티, 서비스 클래스에서 MenuRequestDto, MenuResponseDto의 import 경로가 변경된 것을 확인했습니다. 메뉴 관련 DTO인데 order 패키지에 들어가 있더라고요. 그래서 controller > dto > menu 패키지로 이동시켜 놓고, 각 클래스에서 사용된 경로도 바꿔놓았습니다. 메뉴와 관련된 기능을 개발하실 때 참고하시면 혼란이 없을 것 같습니다. 확인 부탁드립니다!

🧑‍💻 PR 세부 내용

- 메뉴 검색 기능 추가 (/api/menus/serch?storeId=&keyword=)
- 메뉴 권한 추가 -> 제가 PreAutorize 적용되기 전에 권한 확인 로직을 구현해놓아서 PreAutorize 적용하려면 테스트코드랑 기존 코드들 좀 많이 수정해야해서 시간이 부족해서 적용하지 못했습니다. 너무 죄송합니다.
- MenuController, Menu, MenuService 에서 dto 클래스들의 경로를 변경하였음
-  GeminiService에서 호출 실패 시 재시도하는 로직을 추가하였습니다.
- 메뉴 서비스 테스트 코드 추가했습니다.
- 제미나이 서비스 테스트코드 추가했습니다.

📸 스크린샷
![image](https://github.com/user-attachments/assets/34c99f3a-f4a5-4dbf-8b89-af0d83aec6d5)
- 메뉴 검색 기능
